### PR TITLE
Enable ANT+ support

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -175,3 +175,6 @@ BOARD_WPA_SUPPLICANT_PRIVATE_LIB := lib_driver_cmd_qcwcn
 WIFI_DRIVER_MODULE_PATH := "/system/lib/modules/wlan.ko"
 WIFI_DRIVER_MODULE_NAME := "wlan"
 WPA_SUPPLICANT_VERSION := VER_0_8_X
+
+# ANT+
+BOARD_ANT_WIRELESS_DEVICE := "vfs-prerelease"

--- a/device.mk
+++ b/device.mk
@@ -278,6 +278,17 @@ PRODUCT_COPY_FILES += \
     kernel/motorola/msm8937/drivers/staging/prima/firmware_bin/WCNSS_cfg.dat:system/etc/firmware/wlan/prima/WCNSS_cfg.dat \
     $(LOCAL_PATH)/wifi/WCNSS_qcom_cfg.ini:system/etc/firmware/wlan/prima/WCNSS_qcom_cfg.ini
 
+
+#ANT+
+PRODUCT_COPY_FILES += \
+    external/ant-wireless/antradio-library/com.dsi.ant.antradio_library.xml:system/etc/permissions/com.dsi.ant.antradio_library.xml
+
+PRODUCT_PACKAGES += \
+	AntHalService \
+	antradio_app \
+	com.dsi.ant.antradio_library \
+	libantradio
+
 PRODUCT_BUILD_PROP_OVERRIDES += BUILD_UTC_DATE=0
 
 PRODUCT_GMS_CLIENTID_BASE := android-motorola


### PR DESCRIPTION
ANT+ is a wireless protocol used by lots of fitness sensors which is supported by the hardware.
With this patch, apps like "ANT+ Plugin Sampler" will work with cedric.